### PR TITLE
stopTimer 위치 수정

### DIFF
--- a/app/src/main/java/com/anonymous/appilogue/features/login/CertificationFragment.kt
+++ b/app/src/main/java/com/anonymous/appilogue/features/login/CertificationFragment.kt
@@ -33,6 +33,7 @@ class CertificationFragment :
 
         with(binding) {
             certificationBackButton.setOnClickListener {
+                viewModel.stopTimer()
                 activity?.onBackPressed()
             }
 

--- a/app/src/main/java/com/anonymous/appilogue/features/login/LoginEmailFragment.kt
+++ b/app/src/main/java/com/anonymous/appilogue/features/login/LoginEmailFragment.kt
@@ -36,7 +36,6 @@ class LoginEmailFragment :
         FirstButtonInit.buttonInit(binding.emailLoginMoveNextButton)
 
         binding.emailLoginBackButton.setOnClickListener {
-            viewModel.stopTimer()
             activity?.onBackPressed()
         }
 


### PR DESCRIPTION
stopTimer 위치를 잘못넣어서 이메일 입력 -> 인증번호입력창에서 뒤로가기 -> 이메일입력 -> 인증번호 창으로 올시 타이머가 2개돌아가서 2배로 시간이 빠르게 줄고있었습니다.
 위치 수정하여 인증번호 입력창에서 뒤로가기 했을시 타이머 멈추게 했습니다.